### PR TITLE
Simulator Expansion

### DIFF
--- a/ragnar_kinematics/CMakeLists.txt
+++ b/ragnar_kinematics/CMakeLists.txt
@@ -31,9 +31,17 @@ target_link_libraries(ragnar_kinematics
 
 add_executable(ragnar_kinematics_node src/ragnar_test_demo.cpp)
 
+add_executable(ragnar_demo_motions src/ragnar_demo_motions.cpp)
+
+
 target_link_libraries(ragnar_kinematics_node
   ragnar_kinematics
- ${catkin_LIBRARIES}
+  ${catkin_LIBRARIES}
+)
+
+target_link_libraries(ragnar_demo_motions
+  ragnar_kinematics
+  ${catkin_LIBRARIES}
 )
 
 #############

--- a/ragnar_kinematics/src/ragnar_demo_motions.cpp
+++ b/ragnar_kinematics/src/ragnar_demo_motions.cpp
@@ -1,0 +1,149 @@
+#include <ros/ros.h>
+#include <ragnar_kinematics/ragnar_kinematics.h>
+#include <trajectory_msgs/JointTrajectory.h>
+
+static void populateHeader(std_msgs::Header& header)
+{
+  header.frame_id = "base_link";
+  header.stamp = ros::Time::now();
+}
+
+static trajectory_msgs::JointTrajectory makeCircleTrajectory()
+{
+  using namespace trajectory_msgs;
+  // Header
+  JointTrajectory traj;
+  populateHeader(traj.header);
+
+  // Create circle points
+  const double r = 0.1;
+  const double dt = 0.05;
+
+  double pose[4];
+  double joints[4];
+
+  double total_t = dt;
+
+  for (int i = 0; i < 360; ++i)
+  {
+    pose[0] = r * std::cos(i * M_PI / 180.0);
+    pose[1] = r * std::sin(i * M_PI / 180.0);
+    pose[2] = -0.3;
+    pose[3] = 0.0;
+
+    JointTrajectoryPoint pt;
+    if (!ragnar_kinematics::inverse_kinematics(pose, joints))
+    {
+      ROS_WARN_STREAM("Could not solve for: " << pose[0] << " " << pose[1] << " " << pose[2] << " " << pose[3]);
+    }
+    else
+    {
+      pt.positions.assign(joints, joints+4);
+      pt.time_from_start = ros::Duration(total_t);
+      total_t += dt;
+      traj.points.push_back(pt);
+    }
+  }
+  return traj;
+}
+
+// Linear trajectory helpers
+struct RagnarPoint {
+  double joints[4];
+};
+
+struct RagnarPose {
+  RagnarPose() {}
+
+  RagnarPose(double x, double y, double z)
+  {
+    pose[0] = x;
+    pose[1] = y;
+    pose[2] = z;
+    pose[3] = 0.0;
+  }
+
+  double pose[4];
+};
+
+RagnarPose interpPose(const RagnarPose& start, const RagnarPose& stop, double ratio)
+{
+  RagnarPose result;
+  result.pose[0] = start.pose[0] + ratio * (stop.pose[0] - start.pose[0]);
+  result.pose[1] = start.pose[1] + ratio * (stop.pose[1] - start.pose[1]);
+  result.pose[2] = start.pose[2] + ratio * (stop.pose[2] - start.pose[2]);
+  result.pose[3] = start.pose[3] + ratio * (stop.pose[3] - start.pose[3]);
+  return result;
+}
+
+bool linearMove(const RagnarPose& start, const RagnarPose& stop, double ds, std::vector<RagnarPoint>& out)
+{
+  std::vector<RagnarPoint> pts;
+  double delta_x = stop.pose[0] - start.pose[0];
+  double delta_y = stop.pose[1] - start.pose[1];
+  double delta_z = stop.pose[2] - start.pose[2];
+  double delta_s = std::sqrt(delta_x * delta_x + delta_y * delta_y + delta_z * delta_z);
+
+  unsigned steps = static_cast<unsigned>(delta_s / ds) + 1;
+
+  for (unsigned i = 0; i <= steps; i++)
+  {
+    double ratio = static_cast<double>(i) / steps;
+    RagnarPose pose = interpPose(start, stop, ratio);
+    RagnarPoint pt;
+    if (!ragnar_kinematics::inverse_kinematics(pose.pose, pt.joints))
+    {
+      return false;
+    }
+    pts.push_back(pt);
+  }
+
+  out = pts;
+  return true;
+}
+
+static trajectory_msgs::JointTrajectory makeLineTrajectory()
+{
+  using namespace trajectory_msgs;
+  // Header
+  JointTrajectory traj;
+  populateHeader(traj.header);
+
+  std::vector<RagnarPoint> points;
+  RagnarPose start (-0.1, -0.1, -0.3);
+  RagnarPose stop (0.1, 0.1, -0.4);
+
+  if (!linearMove(start, stop, 0.01, points))
+  {
+    throw std::runtime_error("Linear movement planning failed");
+  }
+  
+  const double dt = 0.1;
+  double total_t = dt;
+
+  for (unsigned i = 0; i < points.size(); ++i)
+  {
+    JointTrajectoryPoint pt;  
+    pt.positions.assign(points[i].joints, points[i].joints+4);
+    pt.time_from_start = ros::Duration(total_t);
+    total_t += dt;
+    traj.points.push_back(pt);
+  }
+  return traj;
+}
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "ragnar_demo_motions");
+
+  ros::NodeHandle nh;
+  ros::Publisher traj_pub = nh.advertise<trajectory_msgs::JointTrajectory>("joint_command", 1);
+
+  // trajectory_msgs::JointTrajectory traj = makeLineTrajectory();
+  trajectory_msgs::JointTrajectory traj = makeCircleTrajectory(); 
+  ros::Duration(0.5).sleep();
+
+  traj_pub.publish(traj);
+
+  ros::spin();
+}

--- a/ragnar_simulator/CMakeLists.txt
+++ b/ragnar_simulator/CMakeLists.txt
@@ -131,12 +131,17 @@ include_directories(
 add_executable(ragnar_simulator_node src/ragnar_simulator_node.cpp
                                      src/ragnar_simulator.cpp)
 
+add_executable(ragnar_simulator_test_node src/ragnar_simulator_test_node.cpp)
+
 ## Add cmake target dependencies of the executable
 ## same as for the library above
 # add_dependencies(ragnar_simulator_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 ## Specify libraries to link a library or executable target against
 target_link_libraries(ragnar_simulator_node
+  ${catkin_LIBRARIES}
+)
+target_link_libraries(ragnar_simulator_test_node
   ${catkin_LIBRARIES}
 )
 

--- a/ragnar_simulator/include/ragnar_simulator/ragnar_simulator.h
+++ b/ragnar_simulator/include/ragnar_simulator/ragnar_simulator.h
@@ -4,23 +4,30 @@
 #include <vector>
 #include <string>
 
+#include <trajectory_msgs/JointTrajectory.h>
+
 namespace ragnar_simulator
 {
 
 class RagnarSimulator
 {
 public:
-  RagnarSimulator();
+  RagnarSimulator(const std::vector<double>& seed_pose);
 
   const std::vector<std::string>& getJointNames() const { return joint_names_; }
 
-  const std::vector<double>& getJointPositions() const { return joint_positions_; }
-
-  void setJointPositions(const std::vector<double>& new_state);
+  // Initializes trajectory, start time, and position fields
+  bool setTrajectory(const trajectory_msgs::JointTrajectory& new_trajectory);
+  // Computes the robot position at a given time based on the currently active
+  // trajectory
+  bool computeTrajectoryPosition(const ros::Time& tm, std::vector<double>& output) const;
 
 private:
   std::vector<std::string> joint_names_;
-  std::vector<double> joint_positions_;
+  // State 
+  trajectory_msgs::JointTrajectory traj_;
+  std::vector<double> traj_start_position_; 
+  ros::Time traj_start_time_;
 };
 
 }

--- a/ragnar_simulator/src/ragnar_simulator.cpp
+++ b/ragnar_simulator/src/ragnar_simulator.cpp
@@ -1,16 +1,100 @@
 #include "ragnar_simulator/ragnar_simulator.h"
+#include <ros/console.h>
 
-ragnar_simulator::RagnarSimulator::RagnarSimulator()
+ragnar_simulator::RagnarSimulator::RagnarSimulator(const std::vector<double>& seed_pose)
+  : traj_start_position_(seed_pose)
+  , traj_start_time_(ros::Time::now())
 {
+  if (traj_start_position_.size() != 4)
+    throw std::runtime_error("Size of Ragnar simulator seed pose != 4");
+
   joint_names_.push_back("ragnar_joint1");
   joint_names_.push_back("ragnar_joint2");
   joint_names_.push_back("ragnar_joint3");
   joint_names_.push_back("ragnar_joint4");
-  joint_positions_.resize(joint_names_.size());
 }
 
-void ragnar_simulator::RagnarSimulator::setJointPositions(const std::vector<double>& new_state)
+bool ragnar_simulator::RagnarSimulator::setTrajectory(const trajectory_msgs::JointTrajectory& new_trajectory)
 {
-  joint_positions_ = new_state;
+  ROS_INFO("Setting new active trajectory");
+  // Compute current state
+  ros::Time now = ros::Time::now();
+  std::vector<double> position;
+  computeTrajectoryPosition(now, position);
+
+  // Rollover to the new trajectory
+  traj_start_position_ = position;
+  traj_ = new_trajectory;
+  traj_start_time_ = now;
+
+  return true;
 }
 
+static double linearInterpolate(double start, double stop, double ratio)
+{
+  return start + (stop - start) * ratio;
+}
+
+  // Computes the robot position at a given time based on the currently active
+  // trajectory
+bool ragnar_simulator::RagnarSimulator::computeTrajectoryPosition(const ros::Time& tm, 
+                                                                  std::vector<double>& output) const
+{
+  // Check to see if time is in past of traj
+  if (tm < traj_start_time_ || traj_.points.empty())
+  {
+    output = traj_start_position_;
+    return true;
+  }
+  // check to see if time is past end of traj
+  else if (tm > traj_start_time_ + traj_.points.back().time_from_start)
+  {
+    output = traj_.points.back().positions;
+    return true;
+  }
+  
+  // Otherwise the traj must be within the trajectory
+  ros::Duration dt = tm - traj_start_time_;
+
+  size_t idx = 0;
+  for (size_t i = 0; i < traj_.points.size(); ++i)
+  {
+    if (dt < traj_.points[i].time_from_start)
+    {
+      idx = i;
+      break;
+    }
+  }
+
+  // Grab the two points and interpolate
+  const trajectory_msgs::JointTrajectoryPoint& end_pt = traj_.points[idx];
+
+  // output container
+  std::vector<double> point;
+  point.reserve(traj_start_position_.size());
+
+  if (idx == 0)
+  {
+    // interpolate from start position
+    double ratio = dt.toSec() / end_pt.time_from_start.toSec();
+
+    for (int i = 0; i < 4; ++i)
+    {
+      point.push_back(linearInterpolate(traj_start_position_[i], end_pt.positions[i], ratio));
+    }
+  }
+  else
+  {
+    const trajectory_msgs::JointTrajectoryPoint& start_pt = traj_.points[idx-1];
+    // interpolate between two points
+    double ratio = (dt - start_pt.time_from_start).toSec() / (end_pt.time_from_start - start_pt.time_from_start).toSec();   
+
+    for (int i = 0; i < 4; ++i)
+    {
+      point.push_back(linearInterpolate(start_pt.positions[i], end_pt.positions[i], ratio));
+    }
+  }
+
+  output = point;
+  return true;
+}

--- a/ragnar_simulator/src/ragnar_simulator_node.cpp
+++ b/ragnar_simulator/src/ragnar_simulator_node.cpp
@@ -1,10 +1,10 @@
 #include <ros/ros.h>
 #include <sensor_msgs/JointState.h> // for publishing robot current position
+#include <trajectory_msgs/JointTrajectory.h>
 
 #include "ragnar_simulator/ragnar_simulator.h"
 
-
-void publishCurrentState(const ros::TimerEvent&,
+void publishCurrentState(const ros::TimerEvent& timer,
                          ros::Publisher& pub,
                          const ragnar_simulator::RagnarSimulator& sim)
 {
@@ -12,38 +12,56 @@ void publishCurrentState(const ros::TimerEvent&,
   joint_state.header.frame_id = "world";
   joint_state.header.stamp = ros::Time::now();
   joint_state.name = sim.getJointNames();
-  joint_state.position = sim.getJointPositions();
+  // compute current position
+  sim.computeTrajectoryPosition(timer.current_real, joint_state.position);
+
   pub.publish(joint_state);
 }
 
-void setCurrentState(const sensor_msgs::JointStateConstPtr& state_command,
-                     ragnar_simulator::RagnarSimulator& sim)
+void setCurrentTrajectory(const trajectory_msgs::JointTrajectoryConstPtr& traj,
+                          ragnar_simulator::RagnarSimulator& sim)
 {
-  sim.setJointPositions(state_command->position);
+  ROS_INFO("Setting new trajectory");
+  sim.setTrajectory(*traj);
 }
 
 int main(int argc, char** argv)
 {
+  const static double default_position[] = {-0.07979196, 0.07044869, 
+                                            -0.07044869, 0.07979196};
+
   ros::init(argc, argv, "ragnar_simulator_node");
   ros::NodeHandle nh;
   ros::NodeHandle pnh ("~");
 
   // pnh loads configuration parameters
+  std::vector<double> seed_position;
+  if (!pnh.getParam("initial_position", seed_position))
+  {
+    seed_position.assign(default_position, default_position + 4);
+  }
+
+  double publish_rate;
+  pnh.param<double>("rate", publish_rate, 30.0);
+  
   // instantiate simulation
-  ragnar_simulator::RagnarSimulator sim;
+  ragnar_simulator::RagnarSimulator sim (seed_position);
 
   // create pub/subscribers and wire them up
   ros::Publisher current_state_pub = nh.advertise<sensor_msgs::JointState>("joint_states", 1);
   ros::Subscriber command_state_sub = 
-      nh.subscribe<sensor_msgs::JointState>("joint_command", 1, boost::bind(setCurrentState, 
-                                                                            _1, 
-                                                                            boost::ref(sim)));
+      nh.subscribe<trajectory_msgs::JointTrajectory>("joint_command", 
+                                                     1, 
+                                                     boost::bind(setCurrentTrajectory, 
+                                                                 _1, 
+                                                                 boost::ref(sim)));
   ros::Timer state_publish_timer =
-      nh.createTimer(ros::Duration(0.1), boost::bind(publishCurrentState,
+      nh.createTimer(ros::Duration(1.0/publish_rate), boost::bind(publishCurrentState,
                                                      _1,
                                                      boost::ref(current_state_pub),
                                                      boost::cref(sim)));
 
+  ROS_INFO("Simulator service spinning");
   ros::spin();
   return 0;
 }

--- a/ragnar_simulator/src/ragnar_simulator_test_node.cpp
+++ b/ragnar_simulator/src/ragnar_simulator_test_node.cpp
@@ -1,0 +1,37 @@
+#include <ros/ros.h>
+#include <trajectory_msgs/JointTrajectory.h>
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "ragnar_sim_test");
+
+  ros::NodeHandle nh;
+  ros::Publisher pub = nh.advertise<trajectory_msgs::JointTrajectory>("joint_command", 1);
+
+
+  static double test_pt[] = {0.897913, -0.667189, -1.266242, -0.123857};
+  trajectory_msgs::JointTrajectoryPoint point;
+  point.positions.assign(test_pt, test_pt + 4);
+  point.time_from_start = ros::Duration(10.0);
+
+  static double test_pt2[] = {-1.217134, 1.558858, 1.113690, -0.960308};
+  trajectory_msgs::JointTrajectoryPoint point2;
+  point2.positions.assign(test_pt2, test_pt2 + 4);
+  point2.time_from_start = ros::Duration(20.0);
+
+
+  ros::spinOnce();
+
+  ros::Duration(1.0).sleep();
+
+  trajectory_msgs::JointTrajectory traj;
+  traj.header.frame_id = "world";
+  traj.header.stamp = ros::Time::now();
+  traj.points.push_back(point);
+  traj.points.push_back(point2);
+
+  pub.publish(traj);
+
+  ROS_INFO("Published... spinning til closed");
+  ros::spin();
+}

--- a/ragnar_support/launch/simulate.launch
+++ b/ragnar_support/launch/simulate.launch
@@ -1,0 +1,29 @@
+<launch>
+  <arg
+    name="model" />
+  <arg
+    name="gui"
+    default="False" />
+  <param
+    name="robot_description"
+    textfile="$(find ragnar_support)/urdf/ragnar.urdf" />
+
+  <!-- Ragnar State Publisher -->
+  <node
+    name="ragnar_state_publisher"
+    pkg="ragnar_state_publisher"
+    type="ragnar_state_publisher_node" />
+  
+  <!-- Simulation Node -->
+  <node
+    name="ragnar_simulator"
+    pkg="ragnar_simulator"
+    type="ragnar_simulator_node"
+    output="screen"/>
+
+  <node
+    name="rviz"
+    pkg="rviz"
+    type="rviz"
+    args="-d $(find ragnar_support)/urdf.rviz" />
+</launch>


### PR DESCRIPTION
This PR changes the "ragnar simulator" to work on JointTrajectory messages.

Also adds a simulate.launch to ragnar_support to quickly bring up necessary nodes.

Also adds a new node to ragnar_kinematics, ragnar_demo_motions, which publishes a hardcoded motion plan once and then spins until shutdown.
